### PR TITLE
modifier les méthodes announce et handleChange

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "J5 Hassio Bridge"
 description: "Bridge to interface arduino's (ConfigurableFirmata) with HAssio via Johnny-Five."
-version: "1.1.23"
+version: "1.1.24"
 slug: "j5_ha_bridge"
 init: false
 arch:


### PR DESCRIPTION
des attributs ont été dépréciés dans le message de découverte MQTT pour Home Assistant

corrections proposées par Gemini:
Supprimez les lignes json_attributes_topic et json_attributes_template et assurez-vous que le value_template extrait correctement la valeur de l'état